### PR TITLE
Support additional voice commands

### DIFF
--- a/commands/listen.js
+++ b/commands/listen.js
@@ -79,6 +79,16 @@ module.exports = async function(message, serverQueue) {
             require('./resume')(fakeMessage, serverQueue);
         } else if (text.startsWith('stop')) {
             require('./stop')(fakeMessage, serverQueue);
+        } else if (text.startsWith('search')) {
+            await require('./search')(fakeMessage);
+        } else if (text.startsWith('remove')) {
+            require('./remove')(fakeMessage, serverQueue);
+        } else if (text.startsWith('loop')) {
+            require('./loop')(fakeMessage, serverQueue);
+        } else if (text.startsWith('queue')) {
+            await require('./queue')(fakeMessage, serverQueue);
+        } else if (text.startsWith('shuffle')) {
+            require('./shuffle')(fakeMessage, serverQueue);
         } else {
             message.channel.send('❌ Command not recognized.');
         }


### PR DESCRIPTION
## Summary
- extend `listen` command to recognize search, remove, loop, queue, and shuffle

## Testing
- `npx jest` *(fails: Need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6853eb45f8e08323b01fca378530be6c