### PR TITLE
Handle additional voice command variations

### DIFF
--- a/commands/listen.js
+++ b/commands/listen.js
@@ -85,7 +85,13 @@ module.exports = async function(message, serverQueue) {
             require('./remove')(fakeMessage, serverQueue);
         } else if (text.startsWith('loop')) {
             require('./loop')(fakeMessage, serverQueue);
-        } else if (text.startsWith('queue')) {
+        } else if (
+            text.startsWith('queue') ||
+            text === 'q' ||
+            text.startsWith('q ') ||
+            text === 'cue' ||
+            text.startsWith('cue ')
+        ) {
             await require('./queue')(fakeMessage, serverQueue);
         } else if (text.startsWith('shuffle')) {
             require('./shuffle')(fakeMessage, serverQueue);

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -1,6 +1,36 @@
 module.exports = function (message, serverQueue) {
     const queueConstruct = serverQueue.get(message.guild.id);
     const args = message.content.split(' ').slice(1);
+
+    const numberWords = {
+        zero: 0,
+        one: 1,
+        two: 2,
+        three: 3,
+        four: 4,
+        five: 5,
+        six: 6,
+        seven: 7,
+        eight: 8,
+        nine: 9,
+        ten: 10,
+        eleven: 11,
+        twelve: 12,
+        thirteen: 13,
+        fourteen: 14,
+        fifteen: 15,
+        sixteen: 16,
+        seventeen: 17,
+        eighteen: 18,
+        nineteen: 19,
+        twenty: 20,
+    };
+
+    let firstArg = args[0] ? args[0].toLowerCase() : undefined;
+    if (firstArg && numberWords.hasOwnProperty(firstArg)) {
+        firstArg = String(numberWords[firstArg]);
+        args[0] = firstArg;
+    }
     const indexToRemove = parseInt(args[0]);
 
     if (!queueConstruct || queueConstruct.songs.length === 0) {


### PR DESCRIPTION
## Summary
- support `q` and `cue` pronunciations for the queue voice command
- allow spelled-out numbers for the remove command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f38712d883239fb444e4c092f155