### PR TITLE
Add help command with listen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Text commands are prefixed with `!`:
 - `!search <terms>` – show top YouTube results.
 - `!shuffle` – shuffle upcoming songs.
 - `!remove <position>` – remove a song by its number in the queue.
+- `!help` – display a list of available commands.
 - `!listen` – record a short voice message. The bot transcribes it with Whisper and executes the spoken command (e.g. "play", "skip").
 
 ## Testing

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,0 +1,19 @@
+module.exports = function (message) {
+    const helpMessage = [
+        '**Available Commands:**',
+        '!play <url or search> - play a YouTube video, playlist or Spotify track/playlist.',
+        '!skip - skip the current song.',
+        '!pause - pause playback.',
+        '!resume - resume if paused.',
+        '!stop - stop and leave the voice channel.',
+        '!loop [single|all] - cycle looping modes for one song or the whole queue.',
+        '!queue - display the current queue.',
+        '!search <terms> - show top YouTube results.',
+        '!shuffle - shuffle upcoming songs.',
+        '!remove <position> - remove a song by its number in the queue.',
+        '!listen - record a short voice message and execute the spoken command.',
+        '!help - show this message.'
+    ].join('\n');
+
+    message.channel.send(helpMessage);
+};

--- a/commands/listen.js
+++ b/commands/listen.js
@@ -95,6 +95,8 @@ module.exports = async function(message, serverQueue) {
             await require('./queue')(fakeMessage, serverQueue);
         } else if (text.startsWith('shuffle')) {
             require('./shuffle')(fakeMessage, serverQueue);
+        } else if (text.startsWith('help')) {
+            require('./help')(fakeMessage);
         } else {
             message.channel.send('❌ Command not recognized.');
         }

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const searchCommand = require('./commands/search');
 const shuffleCommand = require('./commands/shuffle');
 const removeCommand = require('./commands/remove');
 const listenCommand = require('./commands/listen');
+const helpCommand = require('./commands/help');
 
 client.once('ready', () => {
     console.log(`Logged in as ${client.user.tag}`);
@@ -55,6 +56,8 @@ client.on('messageCreate', async (message) => {
         removeCommand(message, serverQueue);
     } else if (message.content.startsWith('!listen')) {
         await listenCommand(message, serverQueue);
+    } else if (message.content.startsWith('!help')) {
+        helpCommand(message);
     }
 });
 


### PR DESCRIPTION
## Summary
- show a help message with `!help`
- route `!help` command in index.js
- expose help through listen.js for voice commands
- document the help command in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f8c36f08832387d878fd052851ee