### PR TITLE
Add !think command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Text commands are prefixed with `!`:
 - `!shuffle` – shuffle upcoming songs.
 - `!remove <position>` – remove a song by its number in the queue.
 - `!ask <prompt>` – get a response from a local Ollama API.
+- `!think <prompt>` – get a thoughtful response from the qwen3:14b model.
 - `!help` – display a list of available commands.
 - `!listen` – record a short voice message. The bot transcribes it with Whisper and executes the spoken command (e.g. "play", "skip").
 

--- a/commands/listen.js
+++ b/commands/listen.js
@@ -95,6 +95,8 @@ module.exports = async function(message, serverQueue) {
             await require('./queue')(fakeMessage, serverQueue);
         } else if (text.startsWith('shuffle')) {
             require('./shuffle')(fakeMessage, serverQueue);
+        } else if (text.startsWith('think')) {
+            await require('./think')(fakeMessage);
         } else if (text.startsWith('ask')) {
             await require('./ask')(fakeMessage);
         } else if (text.startsWith('help')) {

--- a/commands/think.js
+++ b/commands/think.js
@@ -1,0 +1,82 @@
+module.exports = async function (message) {
+    const args = message.content.split(' ').slice(1);
+    const prompt = args.join(' ');
+
+    if (!prompt) {
+        return message.channel.send('❌ Please provide a prompt for the think command.');
+    }
+
+    // Let users know the bot is thinking before reaching out to the API
+    await message.channel.send('Let me think... (using qwen3:14b)');
+
+    try {
+        const baseUrl = process.env.OLLAMA_URL || 'http://127.0.0.1:11434';
+        const response = await fetch(`${baseUrl}/api/generate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                model: 'qwen3:14b',
+                prompt,
+                stream: false,
+                options: { think: true }
+            })
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+        let answer = data.response || data.message || 'No response';
+        // Replace <think> blocks with 🤔 emoji and italics, removing empty blocks
+        answer = answer.replace(/<think>([\s\S]*?)<\/think>/gi, (_, text) => {
+            const trimmed = text.trim();
+            return trimmed ? `🤔 *${trimmed}*` : '';
+        });
+
+        function computeUnclosed(str) {
+            const stack = [];
+            const re = /(\*{1,3}|_{1,3})/g;
+            let m;
+            while ((m = re.exec(str)) !== null) {
+                const token = m[1];
+                if (stack.length && stack[stack.length - 1] === token) {
+                    stack.pop();
+                } else {
+                    stack.push(token);
+                }
+            }
+            return stack;
+        }
+
+        // Split long responses while keeping markdown formatting intact.
+        // Default chunk size is 1750 characters to stay well below
+        // Discord's 2000 character limit.
+        function splitResponse(text, maxLen = 1750) {
+            const chunks = [];
+            let prefix = '';
+            while (text.length) {
+                let chunk = text.slice(0, maxLen);
+                if (text.length > maxLen) {
+                    let splitPos = Math.max(chunk.lastIndexOf('\n'), chunk.lastIndexOf(' '));
+                    if (splitPos <= 0) splitPos = maxLen;
+                    chunk = text.slice(0, splitPos);
+                }
+                chunk = prefix + chunk;
+                const unclosed = computeUnclosed(chunk);
+                const closing = unclosed.slice().reverse().join('');
+                chunks.push(chunk + closing);
+                prefix = unclosed.join('');
+                text = text.slice(chunk.length - prefix.length);
+            }
+            return chunks;
+        }
+
+        for (const part of splitResponse(answer)) {
+            await message.channel.send(part.trimStart());
+        }
+    } catch (error) {
+        console.error('Error during !think command:', error);
+        message.channel.send('❌ Failed to get a response from the Ollama API.');
+    }
+};

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const removeCommand = require('./commands/remove');
 const listenCommand = require('./commands/listen');
 const helpCommand = require('./commands/help');
 const askCommand = require('./commands/ask');
+const thinkCommand = require('./commands/think');
 
 client.once('ready', () => {
     console.log(`Logged in as ${client.user.tag}`);
@@ -57,6 +58,8 @@ client.on('messageCreate', async (message) => {
         removeCommand(message, serverQueue);
     } else if (message.content.startsWith('!listen')) {
         await listenCommand(message, serverQueue);
+    } else if (message.content.startsWith('!think')) {
+        await thinkCommand(message);
     } else if (message.content.startsWith('!ask')) {
         await askCommand(message);
     } else if (message.content.startsWith('!help')) {


### PR DESCRIPTION
## Summary
- implement `!think` command using qwen3:14b model with think flag
- route new command in message and voice handlers
- document new command in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855a57c7c908323b91a6486a6e5e985