### PR TITLE
Prevent concurrent image commands

### DIFF
--- a/commands/image.js
+++ b/commands/image.js
@@ -1,15 +1,26 @@
 const { fetch, Agent } = require('undici');
 
+// Track whether an image generation request is in progress
+let isImageRequestActive = false;
+
 module.exports = async function (message) {
     const args = message.content.split(' ').slice(1);
     const prompt = args.join(' ');
+
+    if (isImageRequestActive) {
+        return message.channel.send('❌ An image is already being generated. Please wait for it to finish.');
+    }
 
     if (!prompt) {
         return message.channel.send('❌ Please provide a prompt for the image command.');
     }
 
-    // Notify the user before starting generation
+    // Notify the user before starting generation and mark as active
     await message.channel.send('⏳ Generating image, please wait...');
+    isImageRequestActive = true;
+    const resetTimeout = setTimeout(() => {
+        isImageRequestActive = false;
+    }, 10 * 60 * 1000); // safety timeout matching the request timeout
 
     const apiUrl = process.env.DIFFUSION_URL || 'http://localhost:5000/generate_and_upscale';
 
@@ -36,5 +47,8 @@ module.exports = async function (message) {
     } catch (error) {
         console.error('Error during !image command:', error);
         message.channel.send('❌ Failed to generate the image.');
+    } finally {
+        clearTimeout(resetTimeout);
+        isImageRequestActive = false;
     }
 };


### PR DESCRIPTION
## Summary
- avoid overlapping `!image` commands by tracking ongoing requests
- set a timeout in case the request hangs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857bd11428c8323b2f2e3cdf753d705