### PR TITLE
Stream ask command responses

### DIFF
--- a/commands/ask.js
+++ b/commands/ask.js
@@ -28,7 +28,7 @@ module.exports = async function (message) {
 
     try {
         const baseUrl = process.env.OLLAMA_URL || 'http://127.0.0.1:11434';
-        const body = { model: 'gemma3:12b-it-qat', prompt, stream: false };
+        const body = { model: 'gemma3:12b-it-qat', prompt, stream: true };
         if (images.length) body.images = images;
         const response = await fetch(`${baseUrl}/api/generate`, {
             method: 'POST',
@@ -40,13 +40,9 @@ module.exports = async function (message) {
             throw new Error(`HTTP ${response.status}`);
         }
 
-        const data = await response.json();
-        let answer = data.response || data.message || 'No response';
-        // Replace <think> blocks with 🤔 emoji, removing empty blocks
-        answer = answer.replace(/<think>([\s\S]*?)<\/think>/gi, (_, text) => {
-            const trimmed = text.trim();
-            return trimmed ? `🤔 ${trimmed} 🤔` : '';
-        });
+        if (!response.body) {
+            throw new Error('No response body received');
+        }
 
         function computeUnclosed(str) {
             const stack = [];
@@ -63,32 +59,93 @@ module.exports = async function (message) {
             return stack;
         }
 
-        // Split long responses while keeping markdown formatting intact.
-        // Default chunk size is 1750 characters to stay well below
-        // Discord's 2000 character limit.
-        function splitResponse(text, maxLen = 1750) {
-            const chunks = [];
-            let prefix = '';
-            while (text.length) {
-                let part = text.slice(0, maxLen);
-                if (text.length > maxLen) {
+        const decoder = new TextDecoder();
+        const reader = response.body.getReader();
+        let jsonBuffer = '';
+        let textBuffer = '';
+        let leftoverTag = '';
+        let prefix = '';
+        let inThink = false;
+        let thinkBuffer = '';
+
+        const isTagPrefix = (str) => '<think>'.startsWith(str) || '</think>'.startsWith(str);
+
+        function transformChunk(chunk) {
+            chunk = leftoverTag + chunk;
+            leftoverTag = '';
+            let result = '';
+            for (let i = 0; i < chunk.length;) {
+                if (!inThink && chunk.startsWith('<think>', i)) {
+                    inThink = true;
+                    i += 7;
+                    continue;
+                }
+                if (inThink && chunk.startsWith('</think>', i)) {
+                    inThink = false;
+                    i += 8;
+                    result += `🤔 ${thinkBuffer.trim()} 🤔`;
+                    thinkBuffer = '';
+                    continue;
+                }
+                if (chunk[i] === '<') {
+                    const remaining = chunk.slice(i);
+                    if ((!inThink && isTagPrefix(remaining)) || (inThink && '</think>'.startsWith(remaining))) {
+                        leftoverTag = remaining;
+                        break;
+                    }
+                }
+                if (inThink) {
+                    thinkBuffer += chunk[i];
+                } else {
+                    result += chunk[i];
+                }
+                i++;
+            }
+            return result;
+        }
+
+        async function flushChunks(force = false) {
+            while (textBuffer.length >= 1750 || (force && textBuffer.length)) {
+                let part = textBuffer.slice(0, 1750);
+                if (textBuffer.length > 1750) {
                     let splitPos = Math.max(part.lastIndexOf('\n'), part.lastIndexOf(' '));
-                    if (splitPos <= 0) splitPos = maxLen;
-                    part = text.slice(0, splitPos);
+                    if (splitPos <= 0) splitPos = 1750;
+                    part = textBuffer.slice(0, splitPos);
                 }
                 const chunk = prefix + part;
                 const unclosed = computeUnclosed(chunk);
                 const closing = unclosed.slice().reverse().join('');
-                chunks.push(chunk + closing);
+                await message.channel.send((chunk + closing).trimStart());
                 prefix = unclosed.join('');
-                text = text.slice(part.length);
+                textBuffer = textBuffer.slice(part.length);
             }
-            return chunks;
         }
 
-        for (const part of splitResponse(answer)) {
-            await message.channel.send(part.trimStart());
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            jsonBuffer += decoder.decode(value, { stream: true });
+            const lines = jsonBuffer.split('\n');
+            jsonBuffer = lines.pop();
+            for (const line of lines) {
+                if (!line.trim()) continue;
+                const data = JSON.parse(line);
+                if (data.done) {
+                    textBuffer += transformChunk('');
+                    await flushChunks(true);
+                } else if (data.response) {
+                    textBuffer += transformChunk(data.response);
+                    await flushChunks();
+                }
+            }
         }
+        if (jsonBuffer.trim()) {
+            const data = JSON.parse(jsonBuffer);
+            if (data.response) {
+                textBuffer += transformChunk(data.response);
+            }
+        }
+        await flushChunks(true);
     } catch (error) {
         console.error('Error during !ask command:', error);
         message.channel.send('❌ Failed to get a response from the Ollama API.');


### PR DESCRIPTION
## Summary
- stream the response from Ollama for `!ask`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ea6916188323986783f153ca456d