### PR TITLE
Add conversation context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Text commands are prefixed with `!`:
 - `!search <terms>` – show top YouTube results.
 - `!shuffle` – shuffle upcoming songs.
 - `!remove <position>` – remove a song by its number in the queue.
-- `!ask <prompt>` – get a response from a local Ollama API. Attach images to include them with the prompt.
-- `!think <prompt>` – get a thoughtful response from the qwen3:14b model.
+- `!ask <prompt>` – get a response from a local Ollama API. Attach images to include them with the prompt. Consecutive calls keep the conversation context.
+- `!think <prompt>` – get a thoughtful response from the qwen3:14b model and also continues the conversation from the previous reply.
 - `!image <prompt>` – generate an image using the API at `DIFFUSION_URL`.
 - `!help` – display a list of available commands.
 - `!listen` – record a short voice message. The bot transcribes it with Whisper and executes the spoken command (e.g. "play", "skip", "image").

--- a/commands/ask.js
+++ b/commands/ask.js
@@ -1,4 +1,5 @@
 const streamOllama = require('../ollama');
+const { getContext, setContext } = require('../contextStore');
 
 module.exports = async function (message) {
     const args = message.content.split(' ').slice(1);
@@ -29,7 +30,9 @@ module.exports = async function (message) {
     await message.channel.send('Let me think... (using gemma3:12b-it-qat)');
 
     try {
-        await streamOllama(message, { model: 'gemma3:12b-it-qat', prompt, images });
+        const context = getContext(message.author.id);
+        const newContext = await streamOllama(message, { model: 'gemma3:12b-it-qat', prompt, images, context });
+        setContext(message.author.id, newContext);
     } catch (error) {
         console.error('Error during !ask command:', error);
         message.channel.send('❌ Failed to get a response from the Ollama API.');

--- a/commands/help.js
+++ b/commands/help.js
@@ -12,6 +12,7 @@ module.exports = function (message) {
         '!shuffle - shuffle upcoming songs.',
         '!remove <position> - remove a song by its number in the queue.',
         '!ask <prompt> - ask a question using the local Ollama API. Attach images to include them with the prompt.',
+        '!think <prompt> - get a thoughtful response using qwen3:14b and continue the conversation.',
         '!image <prompt> - generate an image using the API at DIFFUSION_URL.',
         '!listen - record a short voice message and execute the spoken command (e.g. play, skip, image).',
         '!help - show this message.'

--- a/commands/think.js
+++ b/commands/think.js
@@ -1,4 +1,5 @@
 const streamOllama = require('../ollama');
+const { getContext, setContext } = require('../contextStore');
 
 module.exports = async function (message) {
     const args = message.content.split(' ').slice(1);
@@ -12,7 +13,9 @@ module.exports = async function (message) {
     await message.channel.send('Let me think... (using qwen3:14b)');
 
     try {
-        await streamOllama(message, { model: 'qwen3:14b', prompt, options: { think: true } });
+        const context = getContext(message.author.id);
+        const newContext = await streamOllama(message, { model: 'qwen3:14b', prompt, options: { think: true }, context });
+        setContext(message.author.id, newContext);
     } catch (error) {
         console.error('Error during !think command:', error);
         message.channel.send('❌ Failed to get a response from the Ollama API.');

--- a/contextStore.js
+++ b/contextStore.js
@@ -1,0 +1,14 @@
+const contexts = new Map();
+
+module.exports = {
+    getContext(id) {
+        return contexts.get(id);
+    },
+    setContext(id, context) {
+        if (context) {
+            contexts.set(id, context);
+        } else {
+            contexts.delete(id);
+        }
+    }
+};

--- a/test/contextStore.test.js
+++ b/test/contextStore.test.js
@@ -1,0 +1,14 @@
+const { getContext, setContext } = require('../contextStore');
+
+describe('contextStore', () => {
+  test('stores and retrieves context by id', () => {
+    const ctx = [1,2,3];
+    setContext('user', ctx);
+    expect(getContext('user')).toBe(ctx);
+  });
+
+  test('clears context when set to null', () => {
+    setContext('user', null);
+    expect(getContext('user')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- support carrying forward `context` tokens between Ollama calls
- expose a simple store for conversation contexts
- wire `!ask` and `!think` to persist context per user
- mention conversation persistence in README and help
- test the context store

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685801bfa8148323a368a9a30b838b45