### PR TITLE
Increase default chat memory to 50

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ChocolateDude is a Discord music bot written in Node.js. It can play music from 
   `http://127.0.0.1:11434`)
 - The image generation endpoint stored as `DIFFUSION_URL` (defaults to
   `http://localhost:5000/generate_and_upscale`)
+- Optional `CHAT_HISTORY_LIMIT` to control how many messages of context the `!chat` command keeps (defaults to `50`)
 
 The bot relies on the [`nodejs-whisper`](https://www.npmjs.com/package/nodejs-whisper) package which wraps OpenAI's Whisper model. The Whisper model files will be downloaded automatically on first use.
 

--- a/commands/chat.js
+++ b/commands/chat.js
@@ -1,8 +1,9 @@
 const streamOllama = require('../ollama');
 
 // Track chat history per channel so conversations have context
-// Only the last 20 messages are kept per channel
+// Only the last MAX_HISTORY messages are kept per channel
 const histories = new Map();
+const MAX_HISTORY = parseInt(process.env.CHAT_HISTORY_LIMIT || '50', 10); // configurable via env
 
 module.exports = async function (message) {
     const args = message.content.split(' ').slice(1);
@@ -40,7 +41,7 @@ module.exports = async function (message) {
         const reply = await streamOllama.chat(message, { model: 'gemma3:12b-it-qat', messages: history });
 
         history.push({ role: 'assistant', content: reply });
-        histories.set(message.channel.id, history.slice(-20));
+        histories.set(message.channel.id, history.slice(-MAX_HISTORY));
     } catch (error) {
         console.error('Error during !chat command:', error);
         message.channel.send('❌ Failed to get a response from the Ollama API.');


### PR DESCRIPTION
## Summary
- raise the default chat history limit from 20 to 50

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685811f015ec83239f5bd2aefbc58992