### PR TITLE
Add duration to !search output

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -17,7 +17,8 @@ module.exports = async function (message) {
 
         let responseMessage = '🔍 **Top 10 YouTube Search Results:**\n';
         searchResults.slice(0, 10).forEach((result, index) => {
-            responseMessage += `${index + 1}. **${result.title}**\n   URL: <${result.url}>\n`;
+            const duration = result.duration_raw || (result.snippet && result.snippet.duration) || 'N/A';
+            responseMessage += `${index + 1}. **${result.title}** (${duration})\n   URL: <${result.url}>\n`;
         });
 
         message.channel.send(responseMessage);


### PR DESCRIPTION
## Summary
- show the duration of YouTube search results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859a07932a8832390a135e15f124d90