### PR TITLE
Refactor chunked responses

### DIFF
--- a/chunkedSender.js
+++ b/chunkedSender.js
@@ -1,0 +1,40 @@
+function computeUnclosed(str) {
+    const stack = [];
+    const re = /(\*{1,3})/g; // handle only asterisks, ignore underscores
+    let m;
+    while ((m = re.exec(str)) !== null) {
+        const token = m[1];
+        if (stack.length && stack[stack.length - 1] === token) {
+            stack.pop();
+        } else {
+            stack.push(token);
+        }
+    }
+    return stack;
+}
+
+const CHUNK_SIZE = 1950;
+
+function createChunkSender(channel) {
+    let textBuffer = '';
+    let prefix = '';
+    return async function send(text = '', force = false) {
+        textBuffer += text;
+        while (textBuffer.length >= CHUNK_SIZE || (force && textBuffer.length)) {
+            let part = textBuffer.slice(0, CHUNK_SIZE);
+            if (textBuffer.length > CHUNK_SIZE) {
+                let splitPos = Math.max(part.lastIndexOf('\n'), part.lastIndexOf(' '));
+                if (splitPos <= 0) splitPos = CHUNK_SIZE;
+                part = textBuffer.slice(0, splitPos);
+            }
+            const chunk = prefix + part;
+            const unclosed = computeUnclosed(chunk);
+            const closing = unclosed.slice().reverse().join('');
+            await channel.send((chunk + closing).trimStart());
+            prefix = unclosed.join('');
+            textBuffer = textBuffer.slice(part.length);
+        }
+    };
+}
+
+module.exports = { computeUnclosed, createChunkSender };

--- a/test/chunkedSender.test.js
+++ b/test/chunkedSender.test.js
@@ -1,0 +1,29 @@
+const { createChunkSender } = require('../chunkedSender');
+
+describe('createChunkSender', () => {
+  test('splits long text into multiple messages', async () => {
+    const sent = [];
+    const channel = { send: async (msg) => { sent.push(msg); } };
+    const send = createChunkSender(channel);
+    const longText = 'a'.repeat(2000);
+    await send(longText);
+    await send('', true);
+    expect(sent.length).toBeGreaterThan(1);
+    expect(sent.join('')).toBe(longText);
+    for (const msg of sent) {
+      expect(msg.length).toBeLessThanOrEqual(2000);
+    }
+  });
+
+  test('closes unclosed markdown across chunks', async () => {
+    const sent = [];
+    const channel = { send: async (msg) => { sent.push(msg); } };
+    const send = createChunkSender(channel);
+    const text = 'a'.repeat(1949) + '*' + 'b';
+    await send(text);
+    await send('', true);
+    expect(sent.length).toBe(2);
+    expect(sent[0].endsWith('**')).toBe(true);
+    expect(sent[1]).toBe('*b*');
+  });
+});


### PR DESCRIPTION
## Summary
- extract chunked message sending into `chunkedSender.js`
- use the new helper in `ollama.js`
- add unit tests for chunked sending
- bump chunk size to 1950 characters

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859ae62f44883238fb028bf33fc2b9e