### PR TITLE
Add !upscale command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ Text commands are prefixed with `!`:
 - `!chat <prompt>` – converse with the gemma3:12b-it-qat model via `/api/chat`. Previous prompts and responses are kept so the model has context. Attach images to include them with the prompt.
 - `!think <prompt>` – get a thoughtful response from the qwen3:14b model.
 - `!image[:seed] <prompt>` – generate an image using the API at `DIFFUSION_URL`. If a numeric seed is provided, it will be sent along with the prompt and the resulting seed will be shown with the image.
+- `!upscale` – upscale the first attached image using the API at `UPSCALE_URL`.
 - `!music[:length] <prompt> [--lyrics text]` – generate music using the API at `MUSIC_URL`. Specify a length in seconds like `!music:120` and optionally provide lyrics with `--lyrics`.
 - `!wait` – display the waiting list for AI requests.
 - `!help` – display a list of available commands.
 - `!listen` – record a short voice message. The bot transcribes it with Whisper and executes the spoken command (e.g. "play", "skip", "image").
 
-`!ask`, `!chat`, `!think`, `!image` and `!music` calls are processed sequentially using a waiting list of up to 50 requests. Use `!wait` to view the queue.
+`!ask`, `!chat`, `!think`, `!image`, `!upscale` and `!music` calls are processed sequentially using a waiting list of up to 50 requests. Use `!wait` to view the queue.
 
 ## Testing
 

--- a/commands/upscale.js
+++ b/commands/upscale.js
@@ -1,0 +1,61 @@
+const { fetch, Agent } = require('undici');
+const queue = require('../commandLock');
+
+module.exports = async function (message) {
+    const imageAttachment = [...message.attachments.values()].find(att => att.contentType?.startsWith('image/') || att.height);
+
+    if (!imageAttachment) {
+        return message.channel.send('❌ Please attach an image to upscale.');
+    }
+
+    let imageBase64;
+    try {
+        const res = await fetch(imageAttachment.url);
+        if (!res.ok) {
+            throw new Error(`Failed to fetch attachment: HTTP ${res.status}`);
+        }
+        const buf = Buffer.from(await res.arrayBuffer());
+        imageBase64 = buf.toString('base64');
+    } catch (err) {
+        console.error('Error fetching attachment', err);
+        return message.channel.send('❌ Failed to fetch the attached image.');
+    }
+
+    const label = `!upscale by ${message.author.username}`;
+    const ahead = queue.enqueue(label, async () => {
+        await message.channel.send('⏳ Upscaling image, please wait...');
+
+        const apiUrl = process.env.UPSCALE_URL || 'http://172.20.80.1:5000/upscale';
+        try {
+            const agent = new Agent({ headersTimeout: 20 * 60 * 1000 });
+            const response = await fetch(apiUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ image_base64: imageBase64 }),
+                dispatcher: agent
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+
+            const result = await response.json();
+            if (!result.image_base64) {
+                throw new Error("Response missing 'image_base64'");
+            }
+
+            const buffer = Buffer.from(result.image_base64, 'base64');
+            await message.channel.send({ files: [{ attachment: buffer, name: 'upscaled.png' }] });
+        } catch (error) {
+            console.error('Error during !upscale command:', error);
+            message.channel.send('❌ Failed to upscale the image.');
+        }
+    });
+
+    if (ahead === false) {
+        return message.channel.send('❌ The waiting list is full. Please try again later.');
+    }
+    if (ahead > 0) {
+        message.channel.send(`⌛ Added to waiting list. There are ${ahead} request(s) ahead of you.`);
+    }
+};

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const imageCommand = require('./commands/image');
 const chatCommand = require('./commands/chat');
 const musicCommand = require('./commands/music');
 const waitCommand = require('./commands/wait');
+const upscaleCommand = require('./commands/upscale');
 
 client.once('ready', () => {
     console.log(`Logged in as ${client.user.tag}`);
@@ -70,6 +71,8 @@ client.on('messageCreate', async (message) => {
         await askCommand(message);
     } else if (message.content.startsWith('!image')) {
         await imageCommand(message);
+    } else if (message.content.startsWith('!upscale')) {
+        await upscaleCommand(message);
     } else if (message.content.startsWith('!music')) {
         await musicCommand(message);
     } else if (message.content.startsWith('!wait')) {


### PR DESCRIPTION
## Summary
- add `!upscale` command to send attachments to an upscale endpoint
- wire new command into message handler
- document the new command in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be4af03608323a3c7efbbcde9ff30