### PR TITLE
Fix queue announcement

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -250,7 +250,7 @@ module.exports = async function (message, serverQueue) {
         queueConstruct.songs.push(...songsToAdd);
         if (isPlaylist) {
             message.channel.send(`🎵 Added **${songsToAdd.length}** songs from the playlist to the queue!`);
-        } else {
+        } else if (queueConstruct.songs.length > 1) {
             message.channel.send(`🎵 **${songsToAdd[0].title}** (${songsToAdd[0].duration}) has been added to the queue!`);
         }
     }


### PR DESCRIPTION
## Summary
- avoid sending the "has been added to the queue" message when the queue length is less than two

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68851acd57f88323a730f53bc4b6d0c0